### PR TITLE
Update workload.yaml

### DIFF
--- a/config/workload.yaml
+++ b/config/workload.yaml
@@ -19,4 +19,4 @@ spec:
     git:
       ref:
         branch: main
-      url: ssh://git@github.com/sample-accelerators/appsso-starter-java.git
+      url: https://github.com/sample-accelerators/appsso-starter-java.git


### PR DESCRIPTION
Can we change this to https to instead ? Not all TAP has ssh keys enabled and it stops the deployment.